### PR TITLE
upgrade to SDL2

### DIFF
--- a/Playback.m
+++ b/Playback.m
@@ -8,7 +8,7 @@
 
 #import "Playback.h"
 
-#import <SDL/SDL.h>
+#import <SDL2/SDL.h>
 #import "common.h"
 
 static Playback *playback;

--- a/cfxr.xcodeproj/project.pbxproj
+++ b/cfxr.xcodeproj/project.pbxproj
@@ -22,20 +22,20 @@
 		8D15AC2F0486D014006FF6A4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165FFE840EACC02AAC07 /* InfoPlist.strings */; };
 		8D15AC310486D014006FF6A4 /* CfxrDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A37F4ACFDCFA73011CA2CEA /* CfxrDocument.m */; settings = {ATTRIBUTES = (); }; };
 		8D15AC320486D014006FF6A4 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A37F4B0FDCFA73011CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
-		F045CB4724F37A850083782C /* SDL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F01365A724F27CB800A68CB3 /* SDL.framework */; };
-		F045CB4824F37A850083782C /* SDL.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = F01365A724F27CB800A68CB3 /* SDL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F029680A29F066C0005A100E /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F029680929F066C0005A100E /* SDL2.framework */; };
+		F029680B29F066C0005A100E /* SDL2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F029680929F066C0005A100E /* SDL2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		054D4F580DE0982000684DFE /* Copy Frameworks */ = {
+		F029680C29F066C0005A100E /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F045CB4824F37A850083782C /* SDL.framework in Copy Frameworks */,
+				F029680B29F066C0005A100E /* SDL2.framework in Embed Frameworks */,
 			);
-			name = "Copy Frameworks";
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -66,6 +66,7 @@
 		8D15AC360486D014006FF6A4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8D15AC370486D014006FF6A4 /* cfxr.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = cfxr.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F01365A724F27CB800A68CB3 /* SDL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL.framework; path = /Library/Frameworks/SDL.framework; sourceTree = "<absolute>"; };
+		F029680929F066C0005A100E /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = ../../../../Library/Frameworks/SDL2.framework; sourceTree = "<group>"; };
 		F045CB4624F37A580083782C /* cfxr.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = cfxr.entitlements; sourceTree = "<group>"; };
 		F090BAE524F2768B00A0D06C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/CfxrDocument.xib; sourceTree = "<group>"; };
 		F090BAE624F2768B00A0D06C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -79,7 +80,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				775DFF38067A968500C5B868 /* Cocoa.framework in Frameworks */,
-				F045CB4724F37A850083782C /* SDL.framework in Frameworks */,
+				F029680A29F066C0005A100E /* SDL2.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,6 +162,7 @@
 		2A37F4C3FDCFA73011CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F029680929F066C0005A100E /* SDL2.framework */,
 				F01365A724F27CB800A68CB3 /* SDL.framework */,
 				1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */,
 			);
@@ -189,7 +191,7 @@
 				8D15AC2B0486D014006FF6A4 /* Resources */,
 				8D15AC300486D014006FF6A4 /* Sources */,
 				8D15AC330486D014006FF6A4 /* Frameworks */,
-				054D4F580DE0982000684DFE /* Copy Frameworks */,
+				F029680C29F066C0005A100E /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -299,12 +301,13 @@
 		26FC0AA60875C8B900E6366F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = cfxr.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 20200823A;
+				CURRENT_PROJECT_VERSION = 20230419A;
 				DEVELOPMENT_TEAM = X8C8VAWQM2;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -317,13 +320,15 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = cfxr_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = cfxr;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INSTALL_PATH = "$(HOME)/Applications";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 0.3.3;
+				MARKETING_VERSION = 0.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = im.glyph.and.this.is.cfxr;
 				PRODUCT_NAME = cfxr;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -335,11 +340,12 @@
 		26FC0AA70875C8B900E6366F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = cfxr.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 20200823A;
+				CURRENT_PROJECT_VERSION = 20230419A;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = X8C8VAWQM2;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -351,13 +357,15 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = cfxr_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = cfxr;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INSTALL_PATH = "$(HOME)/Applications";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 0.3.3;
+				MARKETING_VERSION = 0.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = im.glyph.and.this.is.cfxr;
 				PRODUCT_NAME = cfxr;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
I wanted to build a universal binary, which meant building against a recent version of the SDL framework, so I fiddled with a couple of options.  I went ahead and did a release here https://github.com/glyph/cfxr/releases/tag/0.3.4 which is codesigned and notarized and everything, and seems to work in my brief testing.